### PR TITLE
Update P3R.exe Hash

### DIFF
--- a/Apps/Persona 3 Reload/App.json
+++ b/Apps/Persona 3 Reload/App.json
@@ -1,5 +1,5 @@
 {
-    "Hash": "855CF7AA8CF1947A",
+    "Hash": "59D3C070E3A2615B",
     "BadHashDescription": "Only Steam is officially supported, thanks. No guarantees of mod support in any other versions. [If you're on Steam and you see this, ask people to update config at Reloaded.Community]",
     "AppId": "p3r.exe",
     "AppStatus": 0,


### PR DESCRIPTION
I have no idea when the XXHASH changed, but my guess is that it was due to the Persona 3 Reload Demo getting put on Steam and that somehow messed with it.