### PR TITLE
Updating a Few Hashes

### DIFF
--- a/Apps/Metaphor ReFantazio/App.json
+++ b/Apps/Metaphor ReFantazio/App.json
@@ -1,5 +1,5 @@
 {
-    "Hash": "8069C2610515C907",
+    "Hash": "14E871807E62AD82",
     "BadHashDescription": "Only Steam is officially supported. No guarantees of mod support in any other versions. [If you're on Steam and you see this, ask people to update config at Reloaded.Community]",
     "AppId": "metaphor.exe",
     "AppStatus": 0,

--- a/Apps/Persona 5 Royal/App.json
+++ b/Apps/Persona 5 Royal/App.json
@@ -1,5 +1,5 @@
 {
-  "Hash": "fea111a0f1fdd035",
+  "Hash": "FEA111A0F1FDD035",
   "BadHashDescription": "Only Steam is officially supported, thanks. No guarantees of mod support in any other versions. [If you're on Steam and you see this, ask people to update config at Reloaded.Community]",
   "AppId": "p5r.exe",
   "AppStatus": 0,

--- a/Apps/Shin Megami Tensei V Vengeance/Launcher.json
+++ b/Apps/Shin Megami Tensei V Vengeance/Launcher.json
@@ -1,5 +1,5 @@
 {
-    "Hash": "2FBED49750F98CE5",
+    "Hash": "AFC17D15083440D9",
     "BadHashDescription": null,
     "AppId": "smt5v.exe",
     "AppStatus": 1,


### PR DESCRIPTION
I went through the installed ATLUS games on my computer and found a couple mismatched hashes, as well as correcting the case type of P5R.exe so it matches the case that the rest of this repository uses.

SMT5V.exe had a mismatched hash, meaning it would not warn users when they were selecting the Launcher instead of the Application.

METAPHOR.exe had a mismatched hash due to the recent update adding LATAM Spanish subtitles to the game.